### PR TITLE
fix: add missing name field to agent-workflow command frontmatter

### DIFF
--- a/commands/agent-workflow.md
+++ b/commands/agent-workflow.md
@@ -1,4 +1,5 @@
 ---
+name: agent-workflow
 description: "Automated multi-agent development workflow with quality gates from idea to production code"
 allowed-tools: ["Task", "Read", "Write", "Edit", "MultiEdit", "Grep", "Glob", "TodoWrite"]
 ---


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

The `commands/agent-workflow.md` frontmatter is missing the required `name` field. Claude Code registers slash commands using the `name` key in frontmatter — without it, the command cannot be invoked as `/agent-workflow`. The frontmatter currently contains only `description` and `allowed-tools`, which is insufficient for command registration.

## Fix

Added `name: agent-workflow` to the frontmatter block. This is the minimal change needed to make the slash command registerable and invocable by users.

```yaml
# Before
---
description: "Automated multi-agent development workflow with quality gates from idea to production code"
allowed-tools: [...]
---

# After
---
name: agent-workflow
description: "Automated multi-agent development workflow with quality gates from idea to production code"
allowed-tools: [...]
---
```

<!-- nlpm-metadata-begin
{"version":1,"findings":[{"rule_id":"BUG-missing-frontmatter","fingerprint":"sha256:f1dd6943ed50dc82642b42b34518339ef8885a3c204d27e5e3e7374fa97a020d"}]}
nlpm-metadata-end -->